### PR TITLE
Pull request for resolved prefix bug

### DIFF
--- a/src/de/fuberlin/wiwiss/pubby/ResourceDescription.java
+++ b/src/de/fuberlin/wiwiss/pubby/ResourceDescription.java
@@ -124,7 +124,7 @@ public class ResourceDescription {
 	}
 
 	private PrefixMapping getPrefixes() {
-		return model;
+		return config.getPrefixes();
 	}
 
 	private Collection getValuesFromMultipleProperties(Collection properties) {


### PR DESCRIPTION
ResourceDescription class was returning describe query result model for
namespace prefixes. For this reason, reuslt page did not contain prefix
declarations and all prefixes was seen as question marks ("?"). Prefix
map of configuration should be returned from getPrefixes method instead
of model field.
