### PR TITLE
PageURL and PathPageURL improvements

### DIFF
--- a/src/main/java/de/fuberlin/wiwiss/pubby/AbsResourceDescription.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/AbsResourceDescription.java
@@ -27,15 +27,15 @@ import de.fuberlin.wiwiss.pubby.Configuration;
  * @author Richard Cyganiak (richard@cyganiak.de)
  * @version $Id$
  */
-public class ResourceDescription {
+public abstract class AbsResourceDescription {
 	private final HypermediaResource hypermediaResource;
-	private final Model model;
+	final Model model;
 	private final Resource resource;
-	private final Configuration config;
+	final Configuration config;
 	private SimplePrefixMapping prefixes = null;
 	private List<ResourceProperty> properties = null;
 	
-	public ResourceDescription(HypermediaResource resource, Model model, 
+	public AbsResourceDescription(HypermediaResource resource, Model model, 
 			Configuration config) {
 		this.hypermediaResource = resource;
 		this.model = model;
@@ -43,7 +43,7 @@ public class ResourceDescription {
 		this.config = config;
 	}
 
-	public ResourceDescription(Resource resource, Model model, Configuration config) {
+	public AbsResourceDescription(Resource resource, Model model, Configuration config) {
 		this.hypermediaResource = null;
 		this.model = model;
 		this.resource = resource;
@@ -133,10 +133,12 @@ public class ResourceDescription {
 	 */
 	private SimplePrefixMapping getPrefixes() {
 		if (prefixes == null) {
-			prefixes = new SimplePrefixMapping(config, model, config.getPrefixes());
+			prefixes = constructPrefixMapping();
 		}
 		return prefixes;
 	}
+
+	abstract SimplePrefixMapping constructPrefixMapping();
 
 	private Collection<RDFNode> getValuesFromMultipleProperties(
 			Collection<Property> properties) {

--- a/src/main/java/de/fuberlin/wiwiss/pubby/AbsResourceDescription.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/AbsResourceDescription.java
@@ -291,6 +291,11 @@ public abstract class AbsResourceDescription {
 				return "?:" + datatypePrefixer.getLocalName();
 			}
 		}
+		public String getGuessedURI() {
+			String uri = config.guessReverseMapping(node.asResource().getURI());
+			return uri != null ? uri : node.asResource().getURI();
+		}
+
 		public int compareTo(Value other) {
 			if (!(other instanceof Value)) {
 				return 0;

--- a/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
@@ -191,4 +191,18 @@ public class Configuration {
 	public List<Dataset> getDatasets() {
 		return datasets;
 	}
+
+	public SimplePrefixMapping getSimplePrefixes() {
+		return new SimplePrefixMapping(this, getPrefixes());
+	}
+
+	public MappedResource mapResource(String uri) {
+		for (Dataset dataset: getDatasets()) {
+			MappedResource mapped = dataset.getMappedResourceFromDatasetURI(uri, this);
+			if (mapped != null) {
+				return mapped;
+			}
+		}
+		return null;
+	}
 }

--- a/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
@@ -162,8 +162,7 @@ public class Configuration {
 		String uri = config.getProperty(CONF.indexResource).getResource().getURI();
 		String resourceBase = getWebApplicationBaseURI() + getWebResourcePrefix();
 		if (!uri.startsWith(resourceBase)) {
-			throw new RuntimeException("conf:indexResource must start with "
-					+ resourceBase);
+			throw new RuntimeException("conf:indexResource must start with " + resourceBase);
 		}
 		return new HypermediaResource(uri.substring(resourceBase.length()), this);
 	}
@@ -187,5 +186,9 @@ public class Configuration {
 			return config.getProperty(CONF.webResourcePrefix).getString();
 		}
 		return "";
+	}
+
+	public List<Dataset> getDatasets() {
+		return datasets;
 	}
 }

--- a/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
@@ -32,6 +32,7 @@ public class Configuration {
 	private final Model model;
 	private final Resource config;
 	private final PrefixMapping prefixes;
+	private final SimplePrefixMapping simplePrefixMapping;
 	private final Collection<Property> labelProperties;
 	private final Collection<Property> commentProperties;
 	private final Collection<Property> imageProperties;
@@ -97,6 +98,9 @@ public class Configuration {
 		// have syntactic sugar in Turtle.
 		ModelUtil.addNSIfUndefined(prefixes, "rdf", RDF.getURI());
 		ModelUtil.addNSIfUndefined(prefixes, "xsd", XSD.getURI());
+		
+		this.simplePrefixMapping = new SimplePrefixMapping(this, prefixes);
+		
 		// If we don't have an indexResource, then add an index builder dataset
 		// as the first dataset. It will be responsible for handling the
 		// homepage/index resource.
@@ -193,7 +197,7 @@ public class Configuration {
 	}
 
 	public SimplePrefixMapping getSimplePrefixes() {
-		return new SimplePrefixMapping(this, getPrefixes());
+		return simplePrefixMapping;
 	}
 
 	/**

--- a/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/Configuration.java
@@ -196,9 +196,54 @@ public class Configuration {
 		return new SimplePrefixMapping(this, getPrefixes());
 	}
 
-	public MappedResource mapResource(String uri) {
+	/**
+	 * Tries to guess a URI that may be being used on the SPARQL endpoint
+	 * that corresponds to the the pubbyResourceURL being used within pubby.
+	 * {@link #mapResource(String)} is the other direction for this mapping.
+	 * Unfortunately, the mapping given by {@link #mapResource(String)}
+	 * is not necessarily one-one, so we can only do a best effort
+	 * reverse. Fortunately, this will generally be good enough, particularly
+	 * if the config file uses config:datasetURIPattern well.
+	 * @param pubbyResourceURL
+	 * @return A URI which will mapResource() to the pubbyResourceURL, or null.
+	 */
+	public String guessReverseMapping(String pubbyResourceURL) {
+		// we first check that this is a pubbyResourceURL,
+		// we guess in the following fashion
+		// 1: we look through the extended prefix mapping, to see if any prefix matches
+		// the first one that does is viewed as definitive, and we then look the prefix up in the initial prefix mapping to get the 'real' URL
+		// 2: if 1 doesn't work, we extract the relative IRI, and then use it with the first dataset whose pattern rule matches.
+		
+		if (!pubbyResourceURL.startsWith(getWebApplicationBaseURI()+getWebResourcePrefix())) {
+			return null;
+		}
+		
+		if (getSimplePrefixes().getNamespace(pubbyResourceURL)!=null) {
+			return getPrefixes().expandPrefix(getSimplePrefixes().qnameFor(pubbyResourceURL));
+		}
+		
+		String local = Dataset.unescapeURIDelimiters(pubbyResourceURL.substring(getWebApplicationBaseURI().length()+getWebResourcePrefix().length()));
+		
+		for (Dataset d:datasets) {
+			String fullURI = d.local2datasetURI(local);
+			if (fullURI != null) {
+				return fullURI;
+			}
+		}
+		return null;
+	}
+	/**
+	 * Pubby works by creating proxy resources on its own server
+	 * for a variety of resources mentioned in the SPARQL endpoint.
+	 * This method maps from the URIs used by the SPARQL endpoint to
+	 * the proxy resources exposed by Pubby.
+	 * 
+	 * @param uriInSparqlEndPoint
+	 * @return A MappedResource whose absoluteURI is the public URI from pubby
+	 */
+	public MappedResource mapResource(String uriInSparqlEndPoint) {
 		for (Dataset dataset: getDatasets()) {
-			MappedResource mapped = dataset.getMappedResourceFromDatasetURI(uri, this);
+			MappedResource mapped = dataset.getMappedResourceFromDatasetURI(uriInSparqlEndPoint, this);
 			if (mapped != null) {
 				return mapped;
 			}

--- a/src/main/java/de/fuberlin/wiwiss/pubby/DataResourceDescription.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/DataResourceDescription.java
@@ -1,0 +1,21 @@
+package de.fuberlin.wiwiss.pubby;
+
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Resource;
+
+
+public class DataResourceDescription extends AbsResourceDescription {
+
+	public DataResourceDescription(HypermediaResource resource, Model model, Configuration config) {
+		super(resource, model, config);
+	}
+
+	public DataResourceDescription(Resource resource, Model model, Configuration config) {
+		super(resource, model, config);
+	}
+
+	SimplePrefixMapping constructPrefixMapping() {
+		return new SimplePrefixMapping(model, config.getPrefixes());
+	}
+
+}

--- a/src/main/java/de/fuberlin/wiwiss/pubby/Dataset.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/Dataset.java
@@ -384,8 +384,15 @@ public class Dataset {
 		return uri.replaceAll("#", "%23").replaceAll("\\?", "%3F");
 	}
 	
-	private String unescapeURIDelimiters(String uri) {
+	public static String unescapeURIDelimiters(String uri) {
 		return uri.replaceAll("%23", "#").replaceAll("%3F", "?");
+	}
+
+	public String local2datasetURI(String local) {
+		if (datasetURIPattern.matcher(local).matches()) {
+			return datasetBase + local;
+		}
+		return null;
 	}
 	
 }

--- a/src/main/java/de/fuberlin/wiwiss/pubby/Dataset.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/Dataset.java
@@ -380,7 +380,7 @@ public class Dataset {
 		return encoded.toString();
 	}
 
-	private String escapeURIDelimiters(String uri) {
+	public static String escapeURIDelimiters(String uri) {
 		return uri.replaceAll("#", "%23").replaceAll("\\?", "%3F");
 	}
 	

--- a/src/main/java/de/fuberlin/wiwiss/pubby/HypermediaResource.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/HypermediaResource.java
@@ -48,28 +48,37 @@ public class HypermediaResource {
 	}
 		
 	public String getPathPageURL(Property property) {
-		return getPathURL("pathpage/", property);
+		return getPagePathURL("pathpage/", property);
 	}
 	
 	public String getPathDataURL(Property property) {
-		return getPathURL("pathdata/", property);
+		return getDataPathURL("pathdata/", property);
 	}
 	
 	public String getInversePathPageURL(Property property) {
-		return getPathURL("pathpage/-", property);
+		return getPagePathURL("pathpage/-", property);
 	}
 	
 	public String getInversePathDataURL(Property property) {
-		return getPathURL("pathdata/-", property);
+		return getDataPathURL("pathdata/-", property);
 	}
-	
-	private String getPathURL(String urlPrefix, Property property) {
+
+	private String getPagePathURL(String urlPrefix, Property property) {
 		SimplePrefixMapping spm = config.getSimplePrefixes();
 		if (spm.getNamespace(property.getURI()) == null) {
 			return null;
 		}
 		return config.getWebApplicationBaseURI() + urlPrefix +
 				spm.qnameFor(property.getURI()) + "/" +
+				relativeIRI;
+	}
+	
+	private String getDataPathURL(String urlPrefix, Property property) {
+		if (config.getPrefixes().qnameFor(property.getURI()) == null) {
+			return null;
+		}
+		return config.getWebApplicationBaseURI() + urlPrefix +
+				config.getPrefixes().qnameFor(property.getURI()) + "/" +
 				relativeIRI;
 	}
 }

--- a/src/main/java/de/fuberlin/wiwiss/pubby/HypermediaResource.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/HypermediaResource.java
@@ -64,11 +64,12 @@ public class HypermediaResource {
 	}
 	
 	private String getPathURL(String urlPrefix, Property property) {
-		if (config.getPrefixes().qnameFor(property.getURI()) == null) {
+		SimplePrefixMapping spm = config.getSimplePrefixes();
+		if (spm.getNamespace(property.getURI()) == null) {
 			return null;
 		}
 		return config.getWebApplicationBaseURI() + urlPrefix +
-				config.getPrefixes().qnameFor(property.getURI()) + "/" +
+				spm.qnameFor(property.getURI()) + "/" +
 				relativeIRI;
 	}
 }

--- a/src/main/java/de/fuberlin/wiwiss/pubby/ModelTranslator.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/ModelTranslator.java
@@ -52,8 +52,11 @@ public class ModelTranslator {
 	}
 	
 	private String getPublicURI(String datasetURI) {
-		MappedResource resource = dataset.getMappedResourceFromDatasetURI(datasetURI, serverConfig);
-		if (resource == null) return datasetURI;
-		return resource.getController().getAbsoluteIRI();
+		for (Dataset dataset: serverConfig.getDatasets()) {
+			MappedResource resource = dataset.getMappedResourceFromDatasetURI(datasetURI, serverConfig);
+			if (resource != null) 
+				return resource.getController().getAbsoluteIRI();
+		}
+		return datasetURI;
 	}
 }

--- a/src/main/java/de/fuberlin/wiwiss/pubby/PageResourceDescription.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/PageResourceDescription.java
@@ -1,0 +1,21 @@
+package de.fuberlin.wiwiss.pubby;
+
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Resource;
+
+
+public class PageResourceDescription extends AbsResourceDescription {
+
+	public PageResourceDescription(HypermediaResource resource, Model model, Configuration config) {
+		super(resource, model, config);
+	}
+
+	public PageResourceDescription(Resource resource, Model model, Configuration config) {
+		super(resource, model, config);
+	}
+
+	SimplePrefixMapping constructPrefixMapping() {
+		return new SimplePrefixMapping(config, model, config.getPrefixes());
+	}
+
+}

--- a/src/main/java/de/fuberlin/wiwiss/pubby/ResourceDescription.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/ResourceDescription.java
@@ -61,7 +61,11 @@ public class ResourceDescription {
 		String label = getBestLanguageMatch(
 				candidates, config.getDefaultLanguage());
 		if (label == null) {
-			return new URIPrefixer(resource, getPrefixes()).getLocalName();
+			if (resource.isAnon()) {
+				return null;
+			} else {
+			   return new URIPrefixer(resource, getPrefixes()).getLocalName();
+			}
 		}
 		return label;
 	}

--- a/src/main/java/de/fuberlin/wiwiss/pubby/ResourceDescription.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/ResourceDescription.java
@@ -16,8 +16,6 @@ import com.hp.hpl.jena.rdf.model.RDFNode;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.rdf.model.Statement;
 import com.hp.hpl.jena.rdf.model.StmtIterator;
-import com.hp.hpl.jena.shared.PrefixMapping;
-import com.hp.hpl.jena.shared.impl.PrefixMappingImpl;
 
 import de.fuberlin.wiwiss.pubby.Configuration;
 
@@ -34,7 +32,7 @@ public class ResourceDescription {
 	private final Model model;
 	private final Resource resource;
 	private final Configuration config;
-	private PrefixMapping prefixes = null;
+	private SimplePrefixMapping prefixes = null;
 	private List<ResourceProperty> properties = null;
 	
 	public ResourceDescription(HypermediaResource resource, Model model, 
@@ -128,16 +126,14 @@ public class ResourceDescription {
 	}
 
 	/**
-	 * Returns a prefix mapping containing all prefixes from the input model
+	 * Returns a mapping from URIs to Prefixes,
+	 * with longer URIs taking precedence over shorter ones
+	 * and containing all prefixes from the input model
 	 * and from the configuration, with the configuration taking precedence.
 	 */
-	private PrefixMapping getPrefixes() {
+	private SimplePrefixMapping getPrefixes() {
 		if (prefixes == null) {
-			prefixes = new PrefixMappingImpl();
-			prefixes.setNsPrefixes(model);
-			for (String prefix: config.getPrefixes().getNsPrefixMap().keySet()) {
-				prefixes.setNsPrefix(prefix, config.getPrefixes().getNsPrefixURI(prefix));
-			}
+			prefixes = new SimplePrefixMapping(config, model, config.getPrefixes());
 		}
 		return prefixes;
 	}

--- a/src/main/java/de/fuberlin/wiwiss/pubby/SimplePrefixMapping.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/SimplePrefixMapping.java
@@ -28,12 +28,10 @@ class SimplePrefixMapping {
 				String uri = ns2p.getKey();
 				String prefix = ns2p.getValue();
 				newStuff.put(Dataset.escapeURIDelimiters(uri), prefix);
-				for (Dataset dataset: config.getDatasets()) {
-					MappedResource mapped = dataset.getMappedResourceFromDatasetURI(uri, config);
-					if (mapped != null) {
-						newStuff.put(mapped.getController().getAbsoluteIRI(),prefix);
-						newStuff.put(Dataset.escapeURIDelimiters(mapped.getController().getAbsoluteIRI()),prefix);
-					}
+				MappedResource mapped = config.mapResource(uri);
+				if (mapped != null) {
+					newStuff.put(mapped.getController().getAbsoluteIRI(),prefix);
+					newStuff.put(Dataset.escapeURIDelimiters(mapped.getController().getAbsoluteIRI()),prefix);
 				}
 			}
 			newStuff.putAll(uri2prefix); // these ones take precedence
@@ -71,6 +69,12 @@ class SimplePrefixMapping {
 			}
 		}
 		return null;
+	}
+
+	public String qnameFor(String uri) {
+		String ns = getNamespace(uri);
+		String prefix = lookupPrefix(ns);
+		return prefix + ":" + uri.substring(ns.length());
 	}
 
 }

--- a/src/main/java/de/fuberlin/wiwiss/pubby/SimplePrefixMapping.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/SimplePrefixMapping.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.shared.PrefixMapping;
 
 class SimplePrefixMapping {
@@ -24,7 +23,21 @@ class SimplePrefixMapping {
 			copyPrefixes(uri2prefix, pm);
 		}
 		if (config != null) {
-			
+			Map<String,String> newStuff = new HashMap<String,String>();
+			for (Map.Entry<String, String> ns2p : uri2prefix.entrySet() ) {
+				String uri = ns2p.getKey();
+				String prefix = ns2p.getValue();
+				newStuff.put(Dataset.escapeURIDelimiters(uri), prefix);
+				for (Dataset dataset: config.getDatasets()) {
+					MappedResource mapped = dataset.getMappedResourceFromDatasetURI(uri, config);
+					if (mapped != null) {
+						newStuff.put(mapped.getController().getAbsoluteIRI(),prefix);
+						newStuff.put(Dataset.escapeURIDelimiters(mapped.getController().getAbsoluteIRI()),prefix);
+					}
+				}
+			}
+			newStuff.putAll(uri2prefix); // these ones take precedence
+			uri2prefix = newStuff;
 		}
 		this.uri2prefix = uri2prefix.entrySet().toArray(new Map.Entry[uri2prefix.size()]);
 		Arrays.sort(this.uri2prefix, new Comparator<Map.Entry<String, String>>(){

--- a/src/main/java/de/fuberlin/wiwiss/pubby/SimplePrefixMapping.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/SimplePrefixMapping.java
@@ -1,0 +1,63 @@
+package de.fuberlin.wiwiss.pubby;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.shared.PrefixMapping;
+
+class SimplePrefixMapping {
+	
+	final Map.Entry<String, String> uri2prefix[];
+
+	SimplePrefixMapping(PrefixMapping ... mappings) {
+		this(null, mappings);
+	}
+
+	@SuppressWarnings("unchecked")
+	public SimplePrefixMapping(Configuration config, PrefixMapping ... mappings) {
+		Map<String,String> uri2prefix = new HashMap<String,String>();
+		for (PrefixMapping pm: mappings) {
+			copyPrefixes(uri2prefix, pm);
+		}
+		if (config != null) {
+			
+		}
+		this.uri2prefix = uri2prefix.entrySet().toArray(new Map.Entry[uri2prefix.size()]);
+		Arrays.sort(this.uri2prefix, new Comparator<Map.Entry<String, String>>(){
+
+			@Override
+			public int compare(Entry<String, String> uri1p1, Entry<String, String> uri2p2) {
+				// longest uris first
+				return uri2p2.getKey().length() - uri1p1.getKey().length();
+			}});
+	}
+
+	private void copyPrefixes(Map<String,String> uri2prefix, PrefixMapping prefixMapping) {
+		for (Map.Entry<String,String> p2ns: prefixMapping.getNsPrefixMap().entrySet()) {
+			uri2prefix.put(p2ns.getValue(), p2ns.getKey());
+		}
+	}
+
+	String lookupPrefix(String uri) {
+		for (Map.Entry<String, String> ns2p : uri2prefix ) {
+			if (uri.equals(ns2p.getKey())) {
+				return ns2p.getValue();
+			}
+		}
+		return null;
+	}
+
+	String getNamespace(String uri) {
+		for (Map.Entry<String, String> ns2p : uri2prefix ) {
+			if (uri.startsWith(ns2p.getKey())) {
+				return ns2p.getKey();
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/de/fuberlin/wiwiss/pubby/URIPrefixer.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/URIPrefixer.java
@@ -1,12 +1,10 @@
 package de.fuberlin.wiwiss.pubby;
 
-import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.shared.PrefixMapping;
 
 /**
  * Helper class that splits URIs into prefix and local name
@@ -20,25 +18,22 @@ public class URIPrefixer {
 	private final String prefix;
 	private final String localName;
 
-	public URIPrefixer(String uri, PrefixMapping prefixes) {
+	public URIPrefixer(String uri, SimplePrefixMapping prefixes) {
 		this(ResourceFactory.createResource(uri), prefixes);
 	}
 	
-	public URIPrefixer(Resource resource, PrefixMapping prefixes) {
+	public URIPrefixer(Resource resource, SimplePrefixMapping prefixes) {
 		this.resource = resource;
 		String uri = resource.getURI();
-		Iterator<String> it = prefixes.getNsPrefixMap().keySet().iterator();
-		while (it.hasNext()) {
-			String entryPrefix = it.next();
-			String entryURI = prefixes.getNsPrefixURI(entryPrefix);
-			if (uri.startsWith(entryURI)) {
-				prefix = entryPrefix;
-				localName = uri.substring(entryURI.length());
-				return;
-			}
+		String namespaceURI = prefixes.getNamespace(uri);
+		if (namespaceURI != null) {
+			localName = uri.substring(namespaceURI.length());;
+			prefix = prefixes.lookupPrefix(namespaceURI);
+			
+		} else {
+			prefix = null;
+			localName = null;
 		}
-		prefix = null;
-		localName = null;
 	}
 	
 	public boolean hasPrefix() {

--- a/src/main/java/de/fuberlin/wiwiss/pubby/servlets/DataURLServlet.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/servlets/DataURLServlet.java
@@ -13,10 +13,11 @@ import com.hp.hpl.jena.rdf.model.StmtIterator;
 import com.hp.hpl.jena.vocabulary.RDFS;
 
 import de.fuberlin.wiwiss.pubby.Configuration;
+import de.fuberlin.wiwiss.pubby.DataResourceDescription;
 import de.fuberlin.wiwiss.pubby.HypermediaResource;
 import de.fuberlin.wiwiss.pubby.MappedResource;
 import de.fuberlin.wiwiss.pubby.ModelResponse;
-import de.fuberlin.wiwiss.pubby.ResourceDescription;
+import de.fuberlin.wiwiss.pubby.AbsResourceDescription;
 import de.fuberlin.wiwiss.pubby.vocab.FOAF;
 
 /**
@@ -77,7 +78,7 @@ public class DataURLServlet extends BaseURLServlet {
 		document.addProperty(FOAF.primaryTopic, r);
 		document.addProperty(RDFS.label, 
 				"RDF description of " + 
-				new ResourceDescription(controller, description, config).getLabel());
+				new DataResourceDescription(controller, description, config).getLabel());
 		
 		// Add provenance. This seems out of place here.
 		for (MappedResource resource: resources) {

--- a/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PageURLServlet.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PageURLServlet.java
@@ -56,7 +56,7 @@ public class PageURLServlet extends BaseURLServlet {
 		Context context = template.getVelocityContext();
 		context.put("project_name", config.getProjectName());
 		context.put("project_link", config.getProjectLink());
-		context.put("uri", resourceDescription.getURI());
+		context.put("uri", config.guessReverseMapping(resourceDescription.getURI()));
 		context.put("server_base", config.getWebApplicationBaseURI());
 		context.put("rdf_link", controller.getDataURL());
 		context.put("disco_link", discoLink);

--- a/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PageURLServlet.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PageURLServlet.java
@@ -19,7 +19,8 @@ import com.hp.hpl.jena.rdf.model.Resource;
 import de.fuberlin.wiwiss.pubby.Configuration;
 import de.fuberlin.wiwiss.pubby.HypermediaResource;
 import de.fuberlin.wiwiss.pubby.MappedResource;
-import de.fuberlin.wiwiss.pubby.ResourceDescription;
+import de.fuberlin.wiwiss.pubby.AbsResourceDescription;
+import de.fuberlin.wiwiss.pubby.PageResourceDescription;
 
 /**
  * A servlet for serving the HTML page describing a resource.
@@ -44,7 +45,7 @@ public class PageURLServlet extends BaseURLServlet {
 		
 		Velocity.setProperty("velocimacro.context.localscope", Boolean.TRUE);
 		
-		ResourceDescription resourceDescription = new ResourceDescription(
+		AbsResourceDescription resourceDescription = new PageResourceDescription(
 				controller, description, config);
 		String discoLink = "http://www4.wiwiss.fu-berlin.de/rdf_browser/?browse_uri=" +
 				URLEncoder.encode(controller.getAbsoluteIRI(), "utf-8");

--- a/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PathDataURLServlet.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PathDataURLServlet.java
@@ -11,10 +11,11 @@ import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.vocabulary.RDFS;
 
 import de.fuberlin.wiwiss.pubby.Configuration;
+import de.fuberlin.wiwiss.pubby.DataResourceDescription;
 import de.fuberlin.wiwiss.pubby.HypermediaResource;
 import de.fuberlin.wiwiss.pubby.MappedResource;
 import de.fuberlin.wiwiss.pubby.ModelResponse;
-import de.fuberlin.wiwiss.pubby.ResourceDescription;
+import de.fuberlin.wiwiss.pubby.AbsResourceDescription;
 import de.fuberlin.wiwiss.pubby.vocab.FOAF;
 
 /**
@@ -53,7 +54,7 @@ public class PathDataURLServlet extends BasePathServlet {
 								? controller.getInversePathDataURL(property) 
 								: controller.getPathDataURL(property), request));
 		document.addProperty(FOAF.primaryTopic, r);
-		String resourceLabel = new ResourceDescription(controller, descriptions, config).getLabel();
+		String resourceLabel = new DataResourceDescription(controller, descriptions, config).getLabel();
 		String propertyLabel = config.getPrefixes().qnameFor(property.getURI());
 		if (isInverse) {
 			document.addProperty(RDFS.label, 

--- a/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PathPageURLServlet.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/servlets/PathPageURLServlet.java
@@ -19,7 +19,8 @@ import com.hp.hpl.jena.rdf.model.StmtIterator;
 import de.fuberlin.wiwiss.pubby.Configuration;
 import de.fuberlin.wiwiss.pubby.HypermediaResource;
 import de.fuberlin.wiwiss.pubby.MappedResource;
-import de.fuberlin.wiwiss.pubby.ResourceDescription;
+import de.fuberlin.wiwiss.pubby.AbsResourceDescription;
+import de.fuberlin.wiwiss.pubby.PageResourceDescription;
 
 /**
  * A servlet for rendering an HTML page describing the blank nodes
@@ -42,16 +43,16 @@ public class PathPageURLServlet extends BasePathServlet {
 		}
 
 		Resource r = descriptions.getResource(controller.getAbsoluteIRI());
-		List<ResourceDescription> resourceDescriptions = new ArrayList<ResourceDescription>();
+		List<AbsResourceDescription> resourceDescriptions = new ArrayList<AbsResourceDescription>();
 		for (Resource value: getPropertyValues(r, property, isInverse) ) {
-		    resourceDescriptions.add(new ResourceDescription( value, descriptions, config));
+		    resourceDescriptions.add(new PageResourceDescription( value, descriptions, config));
 		}
 		for (Resource value: getPropertyValues(r, descriptions.getProperty(config.mapResource(property.getURI()).getController().getAbsoluteIRI()), isInverse) ) {
-		    resourceDescriptions.add(new ResourceDescription( value, descriptions, config));
+		    resourceDescriptions.add(new PageResourceDescription( value, descriptions, config));
 		}
 		
 		Model description = getResourceDescription(resources);
-		ResourceDescription resourceDescription = new ResourceDescription(
+		AbsResourceDescription resourceDescription = new PageResourceDescription(
 				controller, description, config);
 
 		String title = resourceDescription.getLabel() + (isInverse ? " « " : " » ") +

--- a/src/main/webapp/WEB-INF/templates/proptable.vm
+++ b/src/main/webapp/WEB-INF/templates/proptable.vm
@@ -28,7 +28,7 @@
 #if ($value.hasPrefix())
               <a class="uri" href="$value.Node.URI" title="$value.Node.URI"><small>$value.Prefix:</small>$value.LocalName</a>
 #else
-              <small>&lt;</small><a class="uri" href="$value.Node.URI">$value.Node.URI</a><small>&gt;</small>
+              <small>&lt;</small><a class="uri" href="$value.Node.URI">$value.GuessedURI</a><small>&gt;</small>
 #end
 #elseif ($value.Node.isBlank())
               <span class="blank">_:$value.Node.BlankNodeLabel</span>


### PR DESCRIPTION
Hi Richard
so, I have made a moderate amount of change to get pubby to do what I wanted.
This suggests that my use case is somewhat off-center from your development and/or I see the world somewhat differently.

I will sketch my use case, and then describe the changes.

We have all our triples in a single local SPARQL end point, including cached copies of say the RDF ontology, and owl.rdf etc.
The target users for pubby are the developers, particularly those who have little semantic web expertise.
Given this, the careful management of resources and pubby proxy resources with different URLs seems like a confusion that this target audience would rather have glossed over.
In my use case, the data option as opposed to the page option is totally uninteresting.

Thus, I put some effort into managing the mapping between the two mirrored URI spaces.

Specific changes are:

1: Longest namespace URI lookup - we have nested namespaces, and your code was a bit naive for us
   The SimplePrefixMapping class is an improvement even if you are not convinced by the rest of the code

2: In ModelTranslator I use all the datasets to map uris not just the current dataset

3: I map any variant of a namespace URI to the same prefix in SimplePrefixMapping (with non null config)
    This includes ones in the pubby namespace, and ones ending in %23 rather than #. This means that basically
   all my URIs of interest get mapped to qnames, which gloss away the difference between the pubby proxy URIs
   and the originals

4: For data pages (untested) I try to leave the behavior unchanged.

5: I have a method on config that guesses the original URIs for pubby proxy URIs, and use this to munge the display wherever I saw a pubby proxy URI in the raw (I basically don't want to see them)

I hope some or all of this is helpful.

Jeremy

PS On my forked repo, the default branch 'deploy' has the config file that we are using, if that is of any interest - obviously not of general interest.
