### PR TITLE
Fixed the unit tests for the content negotiation.

### DIFF
--- a/src/main/java/de/fuberlin/wiwiss/pubby/HypermediaControls.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/HypermediaControls.java
@@ -66,7 +66,7 @@ public class HypermediaControls {
 	 * (<code>conf:webBase + conf:webResourcePrefix</code>). Otherwise, it
 	 * will be its full absolute IRI with special characters escaped to make
 	 * it safe in constructing paths.
-	 * @return 
+	 * @return the path
 	 */
 	private String getPubbyPath() {
 		if (isHosted) {

--- a/src/main/java/de/fuberlin/wiwiss/pubby/IRIRewriter.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/IRIRewriter.java
@@ -65,7 +65,7 @@ public abstract class IRIRewriter {
 	
 	/**
 	 * Rewrites an IRI.
-	 * @param Any absolute IRI
+	 * @param absoluteIRI absolute IRI
 	 * @return The rewritten form of the IRI
 	 */
 	public abstract String rewrite(String absoluteIRI);
@@ -73,7 +73,7 @@ public abstract class IRIRewriter {
 	/**
 	 * Rewrites an IRI. For any valid IRI,
 	 *  
-	 * @param Any absolute IRI
+	 * @param absoluteIRI absolute IRI
 	 * @return The rewritten form of the IRI
 	 */
 	public abstract String unrewrite(String absoluteIRI);
@@ -165,7 +165,7 @@ public abstract class IRIRewriter {
 	 * 
 	 * @param originalNamespace The namespace to be replaced
 	 * @param rewrittenNamespace The replacement namespace
-	 * @return
+	 * @return the rewriter
 	 */
 	public static IRIRewriter createNamespaceBased(
 			final String originalNamespace, final String rewrittenNamespace) {

--- a/src/main/java/de/fuberlin/wiwiss/pubby/negotiation/ContentTypeNegotiator.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/negotiation/ContentTypeNegotiator.java
@@ -44,10 +44,16 @@ public class ContentTypeNegotiator {
 				userAgentString, originalAcceptHeader, newAcceptHeader));
 	}
 	
+        /**
+         * Get best match for accept and null header. Best match is LAST match.
+         */
 	public MediaRangeSpec getBestMatch(String accept) {
 		return getBestMatch(accept, null);
 	}
 	
+        /**
+         * Get best match for accept or user agent header. Best match is LAST match.
+         */
 	public MediaRangeSpec getBestMatch(String accept, String userAgent) {
 		if (userAgent == null) {
 			userAgent = "";

--- a/src/main/java/de/fuberlin/wiwiss/pubby/negotiation/PubbyNegotiator.java
+++ b/src/main/java/de/fuberlin/wiwiss/pubby/negotiation/PubbyNegotiator.java
@@ -5,16 +5,11 @@ import java.util.regex.Pattern;
 public class PubbyNegotiator {
 	private final static ContentTypeNegotiator pubbyNegotiator;
 	private final static ContentTypeNegotiator dataNegotiator;
-	
+
 	static {
 		pubbyNegotiator = new ContentTypeNegotiator();
 		pubbyNegotiator.setDefaultAccept("text/html");
-		
-		// MSIE (7.0) sends either */*, or */* with a list of other random types,
-		// but always without q values, so it doesn't provide any basis for
-		// actual negotiation. We will simply send HTML to MSIE, no matter what.
-		pubbyNegotiator.addUserAgentOverride(Pattern.compile("MSIE"), null, "text/html");
-		
+
 		// Send Turtle to clients that indicate they accept everything.
 		// This is specifically so that cURL sees Turtle.
 		//
@@ -22,6 +17,15 @@ public class PubbyNegotiator {
 		//       "*/*" too, but I believe that's only when images or scripts
 		//       are requested, not for normal web page requests.   --RC 
 		pubbyNegotiator.addUserAgentOverride(null, "*/*", "text/turtle");
+
+		// MSIE (7.0) sends either */*, or */* with a list of other random types,
+		// but always without q values, so it doesn't provide any basis for
+		// actual negotiation. We will simply send HTML to MSIE, no matter what.
+		pubbyNegotiator.addUserAgentOverride(Pattern.compile("MSIE"), null, "text/html");
+
+		// Some versions of Safari send a broken "*/*" Accept header.
+		// We must override this to send HTML.
+		pubbyNegotiator.addUserAgentOverride(Pattern.compile("Safari/"), "*/*", "text/html");
 
 		pubbyNegotiator.addVariant("text/html;q=0.81")
 				.addAliasMediaType("application/xhtml+xml;q=0.81");
@@ -48,11 +52,11 @@ public class PubbyNegotiator {
 				.addAliasMediaType("text/turtle;q=0.5");
 		dataNegotiator.addVariant("text/plain;q=0.2");
 	}
-	
+
 	public static ContentTypeNegotiator getPubbyNegotiator() {
 		return pubbyNegotiator;
 	}
-	
+
 	public static ContentTypeNegotiator getDataNegotiator() {
 		return dataNegotiator;
 	}

--- a/src/test/java/de/fuberlin/wiwiss/pubby/negotiation/PubbyNegotiatorTest.java
+++ b/src/test/java/de/fuberlin/wiwiss/pubby/negotiation/PubbyNegotiatorTest.java
@@ -4,26 +4,26 @@ import junit.framework.TestCase;
 
 public class PubbyNegotiatorTest extends TestCase {
 	private ContentTypeNegotiator negotiator;
-	
+
 	public void setUp() {
 		negotiator = PubbyNegotiator.getPubbyNegotiator();
 	}
-	
+
 	public void testAcceptRDFXML() {
 		assertEquals("application/rdf+xml",
 				negotiator.getBestMatch("application/rdf+xml").getMediaType());
 	}
-	
+
 	public void testAcceptHTML() {
 		assertEquals("text/html",
 				negotiator.getBestMatch("text/html").getMediaType());
 	}
-	
+
 	public void testAcceptXHTMLGetsHTML() {
 		assertEquals("text/html",
 				negotiator.getBestMatch("application/xhtml+xml").getMediaType());
 	}
-	
+
 	public void testGetTurtle() {
 		assertEquals("application/x-turtle",
 				negotiator.getBestMatch("application/x-turtle").getMediaType());
@@ -32,7 +32,7 @@ public class PubbyNegotiatorTest extends TestCase {
 		assertEquals("application/x-turtle",
 				negotiator.getBestMatch("text/turtle").getMediaType());
 	}
-	
+
 	public void testGetN3() {
 		assertEquals("text/rdf+n3;charset=utf-8",
 				negotiator.getBestMatch("text/rdf+n3").getMediaType());
@@ -41,31 +41,31 @@ public class PubbyNegotiatorTest extends TestCase {
 		assertEquals("text/rdf+n3;charset=utf-8",
 				negotiator.getBestMatch("application/n3").getMediaType());
 	}
-	
+
 	public void testGetNTriples() {
 		assertEquals("text/plain",
 				negotiator.getBestMatch("text/plain").getMediaType());
 	}
-	
+
 	public void testBrowsersGetHTML() {
 		// Safari and Mozilla have text/html;q=0.9,text/plain;q=0.8,*/*;q=0.5
 		// We want them to see HTML
 		assertEquals("text/html", 
 				negotiator.getBestMatch("text/html;q=0.9,text/plain;q=0.8,*/*;q=0.5").getMediaType());
 	}
-	
+
 	public void testAcceptXMLGetsRDFXML() {
 		assertEquals("application/rdf+xml",
 				negotiator.getBestMatch("application/xml").getMediaType());
 		assertEquals("application/rdf+xml",
 				negotiator.getBestMatch("text/xml").getMediaType());
 	}
-	
+
 	public void testNoAcceptGetsHTML() {
 		assertEquals("text/html",
 				negotiator.getBestMatch(null).getMediaType());
 	}
-	
+
 	public void testSafariGetsHTML() {
 		// Some versions of Safari send a broken "*/*" Accept header.
 		// We must override this to send HTML.
@@ -75,11 +75,30 @@ public class PubbyNegotiatorTest extends TestCase {
 						"AppleWebKit/522.11.1 (KHTML, like Gecko) " +
 						"Version/3.0.3 Safari/522.12.1").getMediaType());
 	}
-	
-	public void testAcceptEverythingGetsHTML() {
-		assertEquals("text/html", negotiator.getBestMatch("*/*").getMediaType());
+
+	public void testPlainMSIE7GetsHTML() {
+                // MSIE (7.0) sends either */*, or */* with a list of other random types,
+                // but always without q values, so it doesn't provide any basis for
+                // actual negotiation. We will simply send HTML to MSIE, no matter what.
+		assertEquals("text/html",
+				negotiator.getBestMatch("*/*", 
+						"Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)").getMediaType());
 	}
-	
+
+	public void testCompatibleMSIE7GetsHTML() {
+                // MSIE (7.0) sends either */*, or */* with a list of other random types,
+                // but always without q values, so it doesn't provide any basis for
+                // actual negotiation. We will simply send HTML to MSIE, no matter what.
+		assertEquals("text/html",
+				negotiator.getBestMatch("*/*", 
+                                                "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; SLCC2; " +
+                                                ".NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729;" + 
+                                                "Media Center PC 6.0; .NET4.0C; .NET4.0E)").getMediaType());
+	}
+	public void testAcceptEverythingGetsHTML() {
+		assertEquals("application/x-turtle", negotiator.getBestMatch("*/*").getMediaType());
+	}
+
 	public void testFirefox3GetsHTML() {
 		// Firefox 3.0.1, OS X
 		assertEquals("text/html",
@@ -88,7 +107,7 @@ public class PubbyNegotiatorTest extends TestCase {
 						"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.1) " + 
 						"Gecko/2008070206 Firefox/3.0.1").getMediaType());
 	}
-	
+
 	public void testTabulatorGetsRDF() {
 		// Tabulator 0.8.5 on Firefox 3.0.1, OS X
 		assertEquals("application/rdf+xml",
@@ -99,14 +118,14 @@ public class PubbyNegotiatorTest extends TestCase {
 						"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.0.1) " +
 						"Gecko/2008070206 Firefox/3.0.1").getMediaType());
 	}
-	
+
 	public void testDataURIDefaultsToN3ForFirefox() {
 		assertEquals("text/rdf+n3;charset=utf-8",
 				PubbyNegotiator.getDataNegotiator().getBestMatch(
 						"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 				).getMediaType());
 	}
-	
+
 	public void testDataURIDefaultsToN3ForSafari() {
 		assertEquals("text/rdf+n3;charset=utf-8",
 				PubbyNegotiator.getDataNegotiator().getBestMatch(


### PR DESCRIPTION
Now you can do mvn package without -DskipTests.

In the process I found a bug that prevented MSIE from getting text/html as intended in the code.
